### PR TITLE
GHC 8 and HaLVM 2.2 update

### DIFF
--- a/src/Network/SSH/Keys.hs
+++ b/src/Network/SSH/Keys.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | Key exchange and key generation
@@ -150,7 +149,7 @@ runDh params =
 
      let DH.PublicNumber pub_s = DH.calculatePublic params priv
 
-         computeSecret raw_pub_c = Just (runPut (putMpInt shared))
+         computeSecret raw_pub_c = Just (runPut (putMpInt (os2ip shared)))
            where
            DH.SharedKey shared = DH.getShared params priv
                                $ DH.PublicNumber
@@ -188,7 +187,7 @@ runEcdh curve =
          computeSecret raw_pub_c
            | CryptoPassed pub_c <- pointFromBytes curve raw_pub_c
            , let ECDH.SharedKey shared = ECDH.getShared curve priv pub_c
-           = Just (runPut (putMpInt shared))
+           = Just (runPut (putMpInt (os2ip shared)))
 
            | otherwise = Nothing
 
@@ -211,12 +210,7 @@ runCurve25519dh ::
 runCurve25519dh =
 
      -- fails if key isn't 32 bytes long
-#if MIN_VERSION_cryptonite(0,9,0)
   do CryptoPassed priv <-
-#else
-     -- The cryptonite-0.8 version.
-  do Right priv <-
-#endif
        fmap C25519.secretKey (getRandomBytes 32 :: IO S.ByteString)
 
      -- Section 2: Transmit public key as "string"
@@ -224,12 +218,7 @@ runCurve25519dh =
 
          computeSecret raw_pub_c
              -- fails if key isn't 32 bytes long
-#if MIN_VERSION_cryptonite(0,9,0)
            | CryptoPassed pub_c <-
-#else
-             -- The cryptonite-0.8 version.
-           | Right pub_c <-
-#endif
                C25519.publicKey raw_pub_c
 
              -- Section 4.3: Treat shared key bytes as "integer"

--- a/ssh-hans.cabal
+++ b/ssh-hans.cabal
@@ -50,7 +50,7 @@ library
   build-depends:       base         >=4.7      && <4.10,
                        cereal       >=0.5.1.0  && <0.6,
                        bytestring   >=0.10.4.0 && <0.11,
-                       cryptonite   >=0.9      && <0.21,
+                       cryptonite   >=0.14     && <0.21,
                        memory       >=0.10     && <0.14,
                        transformers >=0.2      && <0.6,
                        containers   >=0.5.5.1  && <0.6,

--- a/ssh-hans.cabal
+++ b/ssh-hans.cabal
@@ -50,12 +50,7 @@ library
   build-depends:       base         >=4.7      && <4.10,
                        cereal       >=0.5.1.0  && <0.6,
                        bytestring   >=0.10.4.0 && <0.11,
-                       -- On HaLVM, cryptonite >=0.9 doesn't build,
-                       -- and the API of cryptonite-0.8 and
-                       -- cryptonite-0.9 are incompatible. So, some
-                       -- code in src/Network/SSH/Keys.hs uses CPP to
-                       -- support cryptonite 0.8 and 0.9.
-                       cryptonite   >=0.8      && <0.10,
+                       cryptonite   >=0.9      && <0.21,
                        memory       >=0.10     && <0.14,
                        transformers >=0.2      && <0.6,
                        containers   >=0.5.5.1  && <0.6,

--- a/ssh-hans.cabal
+++ b/ssh-hans.cabal
@@ -47,7 +47,7 @@ library
 
                        Crypto.MAC.UMAC
 
-  build-depends:       base         >=4.7      && <4.9,
+  build-depends:       base         >=4.7      && <4.10,
                        cereal       >=0.5.1.0  && <0.6,
                        bytestring   >=0.10.4.0 && <0.11,
                        -- On HaLVM, cryptonite >=0.9 doesn't build,
@@ -56,8 +56,8 @@ library
                        -- code in src/Network/SSH/Keys.hs uses CPP to
                        -- support cryptonite 0.8 and 0.9.
                        cryptonite   >=0.8      && <0.10,
-                       memory       >=0.10     && <0.11,
-                       transformers >=0.2      && <0.5,
+                       memory       >=0.10     && <0.14,
+                       transformers >=0.2      && <0.6,
                        containers   >=0.5.5.1  && <0.6,
                        stm          >=2.4.4    && <2.5,
                        async        >=2.0.2    && <2.3


### PR DESCRIPTION
Howdy! Can you pull in the following changes? They allow `ssh-hans` to build against GHC 8, and they update the `cryptonite` constraint now that the HaLVM allows for versions above 0.9.