### PR TITLE
GHC 2020

### DIFF
--- a/src/Network/SSH/PrivateKeyFormat.hs
+++ b/src/Network/SSH/PrivateKeyFormat.hs
@@ -192,30 +192,30 @@ extractPK pkf =
 -- | Merge multiple new OpenSSH private key files into a single one
 -- The file format as defined supports this though openssh doesn't
 -- appear to actually handle it correctly.
-mergePrivateKeys :: [S.ByteString] -> Either String S.ByteString
-mergePrivateKeys xs =
-  do pkfs1 <- traverse parsePrivateKeyFile xs
-     pkf   <- case pkfs1 of
-                [] -> Left "No private key files"
-                pkf:_ -> return pkf
-
-     priv:privs <- traverse (removePadding . pkfPrivateKeys) pkfs1
-
-     let discardCheckBytes = S.drop 8
-         pkf' = pkf { pkfPublicKeys = pkfPublicKeys =<< pkfs1
-                    , pkfPrivateKeys = addPadding
-                                     $ priv
-                            `S.append` S.concat (map discardCheckBytes privs)
-                    }
-
-         lineLen = 70 -- to match openssh's behavior
-         dataLine = convertToBase Base64 (runPut (putPrivateKeyFile pkf'))
-
-     return $ S8.unlines $ [ armorHeader ]
-                        ++ chunks lineLen dataLine
-                        ++ [ armorFooter ]
-
-
+--mergePrivateKeys :: [S.ByteString] -> Either String S.ByteString
+--mergePrivateKeys xs =
+--  do pkfs1 <- traverse parsePrivateKeyFile xs
+--     pkf   <- case pkfs1 of
+--                [] -> Left "No private key files"
+--                pkf:_ -> return pkf
+--
+--     priv:privs <- traverse (removePadding . pkfPrivateKeys) pkfs1
+--
+--     let discardCheckBytes = S.drop 8
+--         pkf' = pkf { pkfPublicKeys = pkfPublicKeys =<< pkfs1
+--                    , pkfPrivateKeys = addPadding
+--                                     $ priv
+--                            `S.append` S.concat (map discardCheckBytes privs)
+--                    }
+--
+--         lineLen = 70 -- to match openssh's behavior
+--         dataLine = convertToBase Base64 (runPut (putPrivateKeyFile pkf'))
+--
+--     return $ S8.unlines $ [ armorHeader ]
+--                        ++ chunks lineLen dataLine
+--                        ++ [ armorFooter ]
+--
+--
 
 
 chunks :: Int -> S.ByteString -> [S.ByteString]

--- a/ssh-hans.cabal
+++ b/ssh-hans.cabal
@@ -44,15 +44,15 @@ library
 
   -- The cryptonite lower bound is based on 0.14 being the earliest
   -- version with 'DH.param_bits'.
-  build-depends:       base         >=4.7,
-                       cereal       >=0.5.1.0  && <0.6,
-                       bytestring   >=0.10.4.0 && <0.11,
-                       cryptonite   >=0.14,
-                       memory       >=0.10,
-                       transformers >=0.2      && <0.6,
-                       containers   >=0.5.5.1  && <0.6,
-                       stm          >=2.4.4    && <2.5,
-                       async        >=2.0.2    && <2.3
+  build-depends:       base,
+                       cereal,
+                       bytestring,
+                       cryptonite,
+                       memory,
+                       transformers,
+                       containers,
+                       stm,
+                       async
 
   c-sources:           cbits/umac64.c
                        cbits/umac128.c
@@ -78,10 +78,10 @@ executable ssh-hans-example-client
   if os(halvm)
     buildable:         False
   else
-    build-depends:     base         >=4.7,
-                       bytestring   >=0.10.6.0 && <0.11,
-                       async        >=2.0.2    && <2.3,
-                       network      >=2.6.2.1  && <2.7,
+    build-depends:     base,
+                       bytestring,
+                       async,
+                       network,
                        ssh-hans
 
     hs-source-dirs:    client
@@ -94,16 +94,16 @@ executable ssh-hans-example-server
   if os(halvm)
     buildable:         False
   else
-    build-depends:     base         >=4.7,
-                       bytestring   >=0.10.6.0 && <0.11,
-                       cereal       >=0.5.1.0  && <0.6,
-                       directory    >=1.2.2.0  && <1.3,
-                       filepath     >=1.3.0.2  && <1.5,
-                       memory       >=0.10,
-                       network      >=2.6.2.1  && <2.7,
-                       setgame      >=1.1      && <1.3,
-                       unix         >=2.7.0.1  && <2.8,
-                       vty          >=5.7      && <5.18,
+    build-depends:     base,
+                       bytestring,
+                       cereal,
+                       directory,
+                       filepath,
+                       memory,
+                       network,
+                       setgame,
+                       unix,
+                       vty,
                        ssh-hans
 
     hs-source-dirs:    server
@@ -115,10 +115,10 @@ test-suite umac
   main-is:             UmacTests.hs
   hs-source-dirs:      tests
   default-language:    Haskell2010
-  build-depends:       base         >=4.7,
+  build-depends:       base,
                        cryptonite,
-                       memory       >=0.10,
-                       bytestring   >=0.10.6.0 && <0.11,
+                       memory,
+                       bytestring,
                        ssh-hans
 
 test-suite tests
@@ -127,9 +127,9 @@ test-suite tests
   other-modules:       Tests.Messages,
                        Tests.Packet
   hs-source-dirs:      tests
-  build-depends:       base >= 4.7 && < 5,
+  build-depends:       base,
                        bytestring,
-                       cereal >= 0.4.0.1,
+                       cereal,
                        test-framework,
                        test-framework-quickcheck2,
                        QuickCheck,


### PR DESCRIPTION
Updates `ssh-hans` so that it builds against reasonably-recent versions of GHC. (Tested with GHC 8.6.5.)